### PR TITLE
fix for module version edge cases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/adisbladis/vgo2nix
 
+go 1.13
+
 require (
 	github.com/orivej/go-nix v0.0.0-20180830055821-dae45d921a44
 	golang.org/x/tools v0.0.0-20180723204246-ded554d0681e


### PR DESCRIPTION
- fix for projects importing different major versions of module
- fix for repos with multiple go.mod files
- improve diagnostic output for errors
- pin to go1.13 (for errors package)